### PR TITLE
Full support for headless services

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ Specification](https://github.com/kubernetes/enhancements/pull/2577).
 ```
 multicluster [ZONES...] {
     kubeconfig KUBECONFIG [CONTEXT]
+    noendpoints
     fallthrough [ZONES...]
 }
 ```
 
 * `kubeconfig` **KUBECONFIG [CONTEXT]** authenticates the connection to a remote k8s cluster using a kubeconfig file. **[CONTEXT]** is optional, if not set, then the current context specified in kubeconfig will be used. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
+* `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints. All endpoint queries and headless service queries will result in an NXDOMAIN.
 * `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the plugin chain, which can include another plugin to handle the query. If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for those zones will be subject to fallthrough.
 
 ## Startup

--- a/object/endpoint.go
+++ b/object/endpoint.go
@@ -1,0 +1,226 @@
+package object
+
+import (
+	"fmt"
+	mcs "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	discovery "k8s.io/api/discovery/v1"
+	discoveryV1beta1 "k8s.io/api/discovery/v1beta1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	LabelClusterId = "multicluster.kubernetes.io/source-cluster"
+)
+
+// Endpoints is a stripped down api.Endpoints with only the items we need for CoreDNS.
+type Endpoints struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
+	Version   string
+	ClusterId string
+	Name      string
+	Namespace string
+	Index     string
+	IndexIP   []string
+	Subsets   []EndpointSubset
+
+	*Empty
+}
+
+// EndpointSubset is a group of addresses with a common set of ports. The
+// expanded set of endpoints is the Cartesian product of Addresses x Ports.
+type EndpointSubset struct {
+	Addresses []EndpointAddress
+	Ports     []EndpointPort
+}
+
+// EndpointAddress is a tuple that describes single IP address.
+type EndpointAddress struct {
+	IP            string
+	Hostname      string
+	NodeName      string
+	TargetRefName string
+}
+
+// EndpointPort is a tuple that describes a single port.
+type EndpointPort struct {
+	Port     int32
+	Name     string
+	Protocol string
+}
+
+// EndpointsKey returns a string using for the index.
+func EndpointsKey(name, namespace string) string { return name + "." + namespace }
+
+// EndpointSliceToEndpoints converts a *discovery.EndpointSlice to a *Endpoints.
+func EndpointSliceToEndpoints(obj meta.Object) (meta.Object, error) {
+	ends, ok := obj.(*discovery.EndpointSlice)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object %v", obj)
+	}
+	e := &Endpoints{
+		Version:   ends.GetResourceVersion(),
+		ClusterId: ends.Labels[LabelClusterId],
+		Name:      ends.GetName(),
+		Namespace: ends.GetNamespace(),
+		Index:     EndpointsKey(ends.Labels[mcs.LabelServiceName], ends.GetNamespace()),
+		Subsets:   make([]EndpointSubset, 1),
+	}
+
+	if len(ends.Ports) == 0 {
+		// Add sentinel if there are no ports.
+		e.Subsets[0].Ports = []EndpointPort{{Port: -1}}
+	} else {
+		e.Subsets[0].Ports = make([]EndpointPort, len(ends.Ports))
+		for k, p := range ends.Ports {
+			ep := EndpointPort{Port: *p.Port, Name: *p.Name, Protocol: string(*p.Protocol)}
+			e.Subsets[0].Ports[k] = ep
+		}
+	}
+
+	for _, end := range ends.Endpoints {
+		if !endpointsliceReady(end.Conditions.Ready) {
+			continue
+		}
+		for _, a := range end.Addresses {
+			ea := EndpointAddress{IP: a}
+			if end.Hostname != nil {
+				ea.Hostname = *end.Hostname
+			}
+			if end.TargetRef != nil {
+				ea.TargetRefName = end.TargetRef.Name
+			}
+			if end.NodeName != nil {
+				ea.NodeName = *end.NodeName
+			}
+			e.Subsets[0].Addresses = append(e.Subsets[0].Addresses, ea)
+			e.IndexIP = append(e.IndexIP, a)
+		}
+	}
+
+	*ends = discovery.EndpointSlice{}
+
+	return e, nil
+}
+
+// EndpointSliceV1beta1ToEndpoints converts a v1beta1 *discovery.EndpointSlice to a *Endpoints.
+func EndpointSliceV1beta1ToEndpoints(obj meta.Object) (meta.Object, error) {
+	ends, ok := obj.(*discoveryV1beta1.EndpointSlice)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object %v", obj)
+	}
+	e := &Endpoints{
+		Version:   ends.GetResourceVersion(),
+		Name:      ends.GetName(),
+		Namespace: ends.GetNamespace(),
+		Index:     EndpointsKey(ends.Labels[mcs.LabelServiceName], ends.GetNamespace()),
+		Subsets:   make([]EndpointSubset, 1),
+	}
+
+	if len(ends.Ports) == 0 {
+		// Add sentinel if there are no ports.
+		e.Subsets[0].Ports = []EndpointPort{{Port: -1}}
+	} else {
+		e.Subsets[0].Ports = make([]EndpointPort, len(ends.Ports))
+		for k, p := range ends.Ports {
+			ep := EndpointPort{Port: *p.Port, Name: *p.Name, Protocol: string(*p.Protocol)}
+			e.Subsets[0].Ports[k] = ep
+		}
+	}
+
+	for _, end := range ends.Endpoints {
+		if !endpointsliceReady(end.Conditions.Ready) {
+			continue
+		}
+		for _, a := range end.Addresses {
+			ea := EndpointAddress{IP: a}
+			if end.Hostname != nil {
+				ea.Hostname = *end.Hostname
+			}
+			if end.TargetRef != nil {
+				ea.TargetRefName = end.TargetRef.Name
+			}
+			// EndpointSlice does not contain NodeName, leave blank
+			e.Subsets[0].Addresses = append(e.Subsets[0].Addresses, ea)
+			e.IndexIP = append(e.IndexIP, a)
+		}
+	}
+
+	*ends = discoveryV1beta1.EndpointSlice{}
+
+	return e, nil
+}
+
+func endpointsliceReady(ready *bool) bool {
+	// Per API docs: a nil value indicates an unknown state. In most cases consumers
+	// should interpret this unknown state as ready.
+	if ready == nil {
+		return true
+	}
+	return *ready
+}
+
+// CopyWithoutSubsets copies e, without the subsets.
+func (e *Endpoints) CopyWithoutSubsets() *Endpoints {
+	e1 := &Endpoints{
+		Version:   e.Version,
+		Name:      e.Name,
+		Namespace: e.Namespace,
+		Index:     e.Index,
+		IndexIP:   make([]string, len(e.IndexIP)),
+	}
+	copy(e1.IndexIP, e.IndexIP)
+	return e1
+}
+
+var _ runtime.Object = &Endpoints{}
+
+// DeepCopyObject implements the ObjectKind interface.
+func (e *Endpoints) DeepCopyObject() runtime.Object {
+	e1 := &Endpoints{
+		Version:   e.Version,
+		Name:      e.Name,
+		Namespace: e.Namespace,
+		Index:     e.Index,
+		IndexIP:   make([]string, len(e.IndexIP)),
+		Subsets:   make([]EndpointSubset, len(e.Subsets)),
+	}
+	copy(e1.IndexIP, e.IndexIP)
+
+	for i, eps := range e.Subsets {
+		sub := EndpointSubset{
+			Addresses: make([]EndpointAddress, len(eps.Addresses)),
+			Ports:     make([]EndpointPort, len(eps.Ports)),
+		}
+		for j, a := range eps.Addresses {
+			ea := EndpointAddress{IP: a.IP, Hostname: a.Hostname, NodeName: a.NodeName, TargetRefName: a.TargetRefName}
+			sub.Addresses[j] = ea
+		}
+		for k, p := range eps.Ports {
+			ep := EndpointPort{Port: p.Port, Name: p.Name, Protocol: p.Protocol}
+			sub.Ports[k] = ep
+		}
+
+		e1.Subsets[i] = sub
+	}
+	return e1
+}
+
+// GetNamespace implements the metav1.Object interface.
+func (e *Endpoints) GetNamespace() string { return e.Namespace }
+
+// SetNamespace implements the metav1.Object interface.
+func (e *Endpoints) SetNamespace(namespace string) {}
+
+// GetName implements the metav1.Object interface.
+func (e *Endpoints) GetName() string { return e.Name }
+
+// SetName implements the metav1.Object interface.
+func (e *Endpoints) SetName(name string) {}
+
+// GetResourceVersion implements the metav1.Object interface.
+func (e *Endpoints) GetResourceVersion() string { return e.Version }
+
+// SetResourceVersion implements the metav1.Object interface.
+func (e *Endpoints) SetResourceVersion(version string) {}

--- a/object/namespace.go
+++ b/object/namespace.go
@@ -1,0 +1,61 @@
+package object
+
+import (
+	"fmt"
+
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Namespace is a stripped down api.Namespace with only the items we need for CoreDNS.
+type Namespace struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
+	Version string
+	Name    string
+
+	*Empty
+}
+
+// ToNamespace returns a function that converts an api.Namespace to a *Namespace.
+func ToNamespace(obj meta.Object) (meta.Object, error) {
+	ns, ok := obj.(*api.Namespace)
+	if !ok {
+		return nil, fmt.Errorf("unexpected object %v", obj)
+	}
+	n := &Namespace{
+		Version: ns.GetResourceVersion(),
+		Name:    ns.GetName(),
+	}
+	*ns = api.Namespace{}
+	return n, nil
+}
+
+var _ runtime.Object = &Namespace{}
+
+// DeepCopyObject implements the ObjectKind interface.
+func (n *Namespace) DeepCopyObject() runtime.Object {
+	n1 := &Namespace{
+		Version: n.Version,
+		Name:    n.Name,
+	}
+	return n1
+}
+
+// GetNamespace implements the metav1.Object interface.
+func (n *Namespace) GetNamespace() string { return "" }
+
+// SetNamespace implements the metav1.Object interface.
+func (n *Namespace) SetNamespace(namespace string) {}
+
+// GetName implements the metav1.Object interface.
+func (n *Namespace) GetName() string { return n.Name }
+
+// SetName implements the metav1.Object interface.
+func (n *Namespace) SetName(name string) {}
+
+// GetResourceVersion implements the metav1.Object interface.
+func (n *Namespace) GetResourceVersion() string { return n.Version }
+
+// SetResourceVersion implements the metav1.Object interface.
+func (n *Namespace) SetResourceVersion(version string) {}

--- a/object/object.go
+++ b/object/object.go
@@ -1,0 +1,113 @@
+// Package object holds functions that convert the objects from the k8s API in
+// to a more memory efficient structures.
+//
+// Adding new fields to any of the structures defined in pod.go, endpoint.go
+// and service.go should not be done lightly as this increases the memory use
+// and will leads to OOMs in the k8s scale test.
+//
+// We can do some optimizations here as well. We store IP addresses as strings,
+// this might be moved to uint32 (for v4) for instance, but then we need to
+// convert those again.
+//
+// Also the msg.Service use in this plugin may be deprecated at some point, as
+// we don't use most of those features anyway and would free us from the *etcd*
+// dependency, where msg.Service is defined. And should save some mem/cpu as we
+// convert to and from msg.Services.
+package object
+
+import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+)
+
+// ToFunc converts one v1.Object to another v1.Object.
+type ToFunc func(v1.Object) (v1.Object, error)
+
+// ProcessorBuilder returns function to process cache events.
+type ProcessorBuilder func(cache.Indexer, cache.ResourceEventHandler) cache.ProcessFunc
+
+// Empty is an empty struct.
+type Empty struct{}
+
+// GetObjectKind implements the ObjectKind interface as a noop.
+func (e *Empty) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+// GetGenerateName implements the metav1.Object interface.
+func (e *Empty) GetGenerateName() string { return "" }
+
+// SetGenerateName implements the metav1.Object interface.
+func (e *Empty) SetGenerateName(name string) {}
+
+// GetUID implements the metav1.Object interface.
+func (e *Empty) GetUID() types.UID { return "" }
+
+// SetUID implements the metav1.Object interface.
+func (e *Empty) SetUID(uid types.UID) {}
+
+// GetGeneration implements the metav1.Object interface.
+func (e *Empty) GetGeneration() int64 { return 0 }
+
+// SetGeneration implements the metav1.Object interface.
+func (e *Empty) SetGeneration(generation int64) {}
+
+// GetSelfLink implements the metav1.Object interface.
+func (e *Empty) GetSelfLink() string { return "" }
+
+// SetSelfLink implements the metav1.Object interface.
+func (e *Empty) SetSelfLink(selfLink string) {}
+
+// GetCreationTimestamp implements the metav1.Object interface.
+func (e *Empty) GetCreationTimestamp() v1.Time { return v1.Time{} }
+
+// SetCreationTimestamp implements the metav1.Object interface.
+func (e *Empty) SetCreationTimestamp(timestamp v1.Time) {}
+
+// GetDeletionTimestamp implements the metav1.Object interface.
+func (e *Empty) GetDeletionTimestamp() *v1.Time { return &v1.Time{} }
+
+// SetDeletionTimestamp implements the metav1.Object interface.
+func (e *Empty) SetDeletionTimestamp(timestamp *v1.Time) {}
+
+// GetDeletionGracePeriodSeconds implements the metav1.Object interface.
+func (e *Empty) GetDeletionGracePeriodSeconds() *int64 { return nil }
+
+// SetDeletionGracePeriodSeconds implements the metav1.Object interface.
+func (e *Empty) SetDeletionGracePeriodSeconds(*int64) {}
+
+// GetLabels implements the metav1.Object interface.
+func (e *Empty) GetLabels() map[string]string { return nil }
+
+// SetLabels implements the metav1.Object interface.
+func (e *Empty) SetLabels(labels map[string]string) {}
+
+// GetAnnotations implements the metav1.Object interface.
+func (e *Empty) GetAnnotations() map[string]string { return nil }
+
+// SetAnnotations implements the metav1.Object interface.
+func (e *Empty) SetAnnotations(annotations map[string]string) {}
+
+// GetFinalizers implements the metav1.Object interface.
+func (e *Empty) GetFinalizers() []string { return nil }
+
+// SetFinalizers implements the metav1.Object interface.
+func (e *Empty) SetFinalizers(finalizers []string) {}
+
+// GetOwnerReferences implements the metav1.Object interface.
+func (e *Empty) GetOwnerReferences() []v1.OwnerReference { return nil }
+
+// SetOwnerReferences implements the metav1.Object interface.
+func (e *Empty) SetOwnerReferences([]v1.OwnerReference) {}
+
+// GetClusterName implements the metav1.Object interface.
+func (e *Empty) GetClusterName() string { return "" }
+
+// SetClusterName implements the metav1.Object interface.
+func (e *Empty) SetClusterName(clusterName string) {}
+
+// GetManagedFields implements the metav1.Object interface.
+func (e *Empty) GetManagedFields() []v1.ManagedFieldsEntry { return nil }
+
+// SetManagedFields implements the metav1.Object interface.
+func (e *Empty) SetManagedFields(managedFields []v1.ManagedFieldsEntry) {}

--- a/parse_test.go
+++ b/parse_test.go
@@ -14,17 +14,15 @@ func TestParseRequest(t *testing.T) {
 		expected string // output from r.String()
 	}{
 		// valid SRV request
-		{"_http._tcp.webs.mynamespace.svc.inter.webs.tests.", "http.tcp..webs.mynamespace.svc"},
-		// wildcard acceptance
-		{"*.any.*.any.svc.inter.webs.tests.", "*.any..*.any.svc"},
+		{"_http._tcp.webs.mynamespace.svc.inter.webs.tests.", "http.tcp...webs.mynamespace.svc"},
 		// A request of endpoint
-		{"1-2-3-4.webs.mynamespace.svc.inter.webs.tests.", "*.*.1-2-3-4.webs.mynamespace.svc"},
+		{"1-2-3-4.cluster.webs.mynamespace.svc.inter.webs.tests.", "*.*.1-2-3-4.cluster.webs.mynamespace.svc"},
 		// bare zone
-		{"inter.webs.tests.", "....."},
+		{"inter.webs.tests.", "......"},
 		// bare svc type
-		{"svc.inter.webs.tests.", "....."},
+		{"svc.inter.webs.tests.", "......"},
 		// bare pod type
-		{"pod.inter.webs.tests.", "....."},
+		{"pod.inter.webs.tests.", "......"},
 	}
 	for i, tc := range tests {
 		m := new(dns.Msg)


### PR DESCRIPTION
closes #1 

Adding support for headless services. Following [multi-cluster DNS spec ](https://docs.google.com/document/d/1-jy1WM4Tb4iz4opBTxviap5PnpfRWd-NZvwhmZWOpRk/edit#). Examples of supported queries:

A query
```
$ dig A nginx.my-namespace.svc.clusterset.local

;; ANSWER SECTION:
nginx.my-namespace.svc.clusterset.local.	5 IN	A	10.244.0.9
nginx.my-namespace.svc.clusterset.local.	5 IN	A	10.244.0.10
nginx.my-namespace.svc.clusterset.local.	5 IN	A	10.244.0.8
```

SRV query
```
$ dig SRV nginx.my-namespace.svc.clusterset.local

;; ANSWER SECTION:
nginx.my-namespace.svc.clusterset.local.	5 IN	SRV	0 33 80 10-244-0-10.clusterid.nginx.my-namespace.svc.clusterset.local.
nginx.my-namespace.svc.clusterset.local.	5 IN	SRV	0 33 80 10-244-0-8.clusterid.nginx.my-namespace.svc.clusterset.local.
nginx.my-namespace.svc.clusterset.local.	5 IN	SRV	0 33 80 10-244-0-9.clusterid.nginx.my-namespace.svc.clusterset.local.
```

Endpoint query
```
$ dig 10-244-0-10.clusterid.nginx.my-namespace.svc.clusterset.local

;; ANSWER SECTION:
10-244-0-10.clusterid.nginx.my-namespace.svc.clusterset.local.	5 IN A 10.244.0.10
```
